### PR TITLE
Testing GitHub token permissions

### DIFF
--- a/permtest.md
+++ b/permtest.md
@@ -1,0 +1,1 @@
+# this tests new github token permissions


### PR DESCRIPTION
This PR tests if it was necessary to have the 'pull-requests: write' permission for our GitHub token. If it's not necessary, the default reviewer (mattn02) should automatically be assigned.